### PR TITLE
Make post body an content type possible from complex requests

### DIFF
--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -11,6 +11,10 @@
 // Initialize constants
 const char* HttpClient::kUserAgent = "Arduino/2.1";
 const char* HttpClient::kContentLengthPrefix = HTTP_HEADER_CONTENT_LENGTH ": ";
+// Store body and content type pointers here so they can be sent also from a complex
+// request with additional headers
+char* HttpClient::pBody = NULL;
+char* HttpClient::pContentType = NULL;
 
 #ifdef PROXY_ENABLED // currently disabled as introduces dependency on Dns.h in Ethernet
 HttpClient::HttpClient(Client& aClient, const char* aProxy, uint16_t aProxyPort)
@@ -95,6 +99,10 @@ int HttpClient::startRequest(const char* aServerName, uint16_t aServerPort, cons
         finishHeaders(aContentType, aBody);
     }
     // else we'll call it in endRequest or in the first call to print, etc.
+    else {
+		pBody = (char *)aBody;
+		pContentType = (char *)aContentType;
+    }
 
     return ret;
 }
@@ -138,6 +146,10 @@ int HttpClient::startRequest(const IPAddress& aServerAddress, const char* aServe
         finishHeaders(aContentType, aBody);
     }
     // else we'll call it in endRequest or in the first call to print, etc.
+    else {
+		pBody = (char *)aBody;
+		pContentType = (char *)aContentType;
+    }
 
     return ret;
 }
@@ -298,7 +310,9 @@ void HttpClient::endRequest()
     if (iState < eRequestSent)
     {
         // We still need to finish off the headers
-        finishHeaders(NULL, NULL);
+        finishHeaders(pContentType, pBody);
+	pBody = NULL;
+	pContentType = NULL;
     }
     // else the end of headers has already been sent, so nothing to do here
 }

--- a/HttpClient.h
+++ b/HttpClient.h
@@ -457,6 +457,8 @@ protected:
     IPAddress iProxyAddress;
     uint16_t iProxyPort;
     uint32_t iHttpResponseTimeout;
+	static char* pBody;
+	static char* pContentType;
 };
 
 #endif


### PR DESCRIPTION
I was trying to use your changes to the original amcewen library so I could send a body in a post request, but my request has additional headers and so I need to use beginRequest() and endRequest(). I noticed that body was not sent in these conditions because finishHeaders() was being called always with NULL as parameters from endRequest(). So I added two variables to store pointers to the body and content type char arrays so they can be used later in the case finishHeaders() is called later from outside startRequest. 
